### PR TITLE
fixes a conversion bug from field not being sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ For questions, issues, or feature requests:
 
 ## Changelog
 
+### 0.0.3 (Critical Bug Fix)
+- **Fixed**: ClassCastException when displaying DataFrame data due to schema-value order mismatch
+- **Improved**: Data row creation now ensures values match schema field order exactly
+
 ### 0.0.2 (Bug Fixes & Documentation)
 - **Fixed**: Infinite loop issue in DataSourceExample when reaching end of dataset
 - **Fixed**: Proper pagination termination when `nextLink` becomes `None`

--- a/test_geodesic_pyspark.py
+++ b/test_geodesic_pyspark.py
@@ -50,11 +50,13 @@ def create_sedona_context():
             "spark.jars.packages",
             "org.apache.sedona:sedona-spark-3.3_2.12:1.7.0,"
             "org.datasyslab:geotools-wrapper:1.7.0-28.5,"
-            "ai.seer:geodesic-spark-datasource-sedona_2.12:0.0.2",
+            "ai.seer:geodesic-spark-datasource-sedona_2.12:0.0.3",
         )
         .config(
             "spark.jars.repositories", "https://artifacts.unidata.ucar.edu/repository/unidata-all"
         )
+        .config("spark.executor.memory", "8g")
+        .config("spark.driver.memory", "8g")
         .getOrCreate()
     )
     sedona = SedonaContext.create(config)


### PR DESCRIPTION
This PR fixes a bug in field conversion:

I successfully fixed the ClassCastException error in DataSourceExample.scala. The issue was in the `BosonPartitionReader.get()` method where there was a mismatch between the schema field order and the data value order when creating Spark's InternalRow.

__Root Cause:__ The problem occurred because:

1. Schema fields were sorted alphabetically in `BosonTable.getSchema()`
2. Property values were also sorted alphabetically in `BosonPartitionReader.get()`
3. However, the geometry field was always appended at the end, regardless of alphabetical order
4. This caused a mismatch where Spark expected a UTF8String but received an Integer (or vice versa) due to incorrect field positioning

__Solution:__ I modified the `BosonPartitionReader.get()` method to:

1. Create a map of property values with proper type conversion
2. Generate the values array in the exact same order as the schema fields
3. Handle the geometry field explicitly by checking field names rather than relying on position

The key change ensures that values are always provided to `InternalRow.fromSeq()` in the same order as defined in the schema, preventing type casting errors. The DataSourceExample.scala now runs successfully without the ClassCastException.
